### PR TITLE
Fix __packed attribute for userspace facing mISDN header

### DIFF
--- a/include/linux/mISDNif.h
+++ b/include/linux/mISDNif.h
@@ -256,7 +256,7 @@
 struct mISDNhead {
 	unsigned int	prim;
 	unsigned int	id;
-}  __packed;
+} __attribute__((__packed__));
 
 #define MISDN_HEADER_LEN	sizeof(struct mISDNhead)
 #define MAX_DATA_SIZE		2048


### PR DESCRIPTION
Compilation of lcr failed with an error message that
"__packed" is defined multiple times.

-> the compiler will create an instance of the structure
named "__packed" for every source file including the header file.

__packed is valid in kernel space only.
